### PR TITLE
fix: reduce num-validators for local devnet

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - testnet
       - generate-genesis
       - --fork=deneb
-      - --num-validators=64
+      - --num-validators=4
       - --genesis-time-delay=0
       - --output-ssz=/consensus/genesis.ssz
       - --chain-config-file=/consensus/config.yml
@@ -155,7 +155,7 @@ services:
       - --beacon-rpc-provider=l1-beacon-chain:4000
       - --datadir=/consensus/validatordata
       - --accept-terms-of-use
-      - --interop-num-validators=64
+      - --interop-num-validators=4
       - --interop-start-index=0
       - --chain-config-file=/consensus/config.yml
       - --verbosity=info


### PR DESCRIPTION
# Summary

Local devnet testing was experiencing performance issues with block production stalling, transaction timeouts, and high CPU usage from the validator and beacon chain services.

# Root Cause

The configuration used 64 validators, which is production-scale and creates unnecessary resource overhead for local development testing.

# Solution

Reduced validator count from 64 to 4:

```diff
# l1-create-beacon-chain-genesis service
- --num-validators=64
+ --num-validators=4

# l1-validator service  
- --interop-num-validators=64
+ --interop-num-validators=4
```