### PR TITLE
Add innertx flag to op-geth-rpc

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -242,6 +242,7 @@ services:
       - --authrpc.jwtsecret=/jwt.txt
       - --rollup.sequencerhttp=http://op-geth-seq:8545
       - --rollup.enabletxpooladmission
+      - --innertx
 
   op-seq:
     image: "${OP_STACK_IMAGE_TAG}"


### PR DESCRIPTION
## Summary
- Add inner transactions flag to docker compose in op-geth-rpc to enable innertx functionality when running devnet script