### PR TITLE
fix: change L2 rpc url in example.env

### DIFF
--- a/test/example.env
+++ b/test/example.env
@@ -14,7 +14,7 @@ CHAIN_ID=196
 RICH_L1_PRIVATE_KEY=0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356
 
 L1_RPC_URL=http://localhost:8545
-L2_RPC_URL=http://localhost:8123
+L2_RPC_URL=http://localhost:8124
 L1_RPC_URL_IN_DOCKER=http://l1-geth:8545
 L2_RPC_URL_IN_DOCKER=http://op-geth-seq:8545
 L1_BEACON_URL_IN_DOCKER=http://l1-beacon-chain:3500


### PR DESCRIPTION
# Summary 
Change `L2_RPC_URL` default value in `example.env` to `localhost:8124`