### PR TITLE
devnet: add static peers config into rpc nodes

### DIFF
--- a/test/config-op/test.geth.rpc.config.toml
+++ b/test/config-op/test.geth.rpc.config.toml
@@ -16,6 +16,7 @@ JWTSecret = "/jwt.txt"
 [Node.P2P]
 MaxPeers = 30
 DiscoveryV5 = true
+StaticNodes = []
 TrustedNodes = []
 
 [Eth]

--- a/test/scripts/add-peers.sh
+++ b/test/scripts/add-peers.sh
@@ -110,6 +110,8 @@ if [ "$LAUNCH_RPC_NODE" = "true" ]; then
     if [ "$RPC_TYPE" = "op-geth-rpc" ]; then
         cp ./config-op/test.geth.rpc.config.toml ./config-op/gen.test.geth.rpc.config.toml
         # Here we use # as delimiter to avoid escaping // in enode URLs
+        # Add as both StaticNodes for peers, and TrustedNodes to bypass peer limits
+        sed_inplace 's#StaticNodes = \[\]#StaticNodes = \['"$OP_RPC_TRUSTED_NODES"'\]#' ./config-op/gen.test.geth.rpc.config.toml
         sed_inplace 's#TrustedNodes = \[\]#TrustedNodes = \['"$OP_RPC_TRUSTED_NODES"'\]#' ./config-op/gen.test.geth.rpc.config.toml
     elif [ "$RPC_TYPE" = "op-reth-rpc" ]; then
         cp ./config-op/test.reth.rpc.config.toml ./config-op/gen.test.reth.rpc.config.toml


### PR DESCRIPTION
## Summary

- Resolve issue on add-peers step. Adding sequencer EL enodes as trusted nodes are not sufficient for p2p as they are only static configurations to always allow peer connections to these nodes
- Add enode to the static nodes configuration to ensure p2p txs gossiping on the txpools