### PR TITLE
optimize op-contract and opstack image

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -1,0 +1,26 @@
+FROM golang:1.24.4
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    jq \
+    make \
+    gcc \
+    nodejs \
+    npm \
+    bash \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+ARG TARGETARCH
+RUN case ${TARGETARCH} in \
+            "amd64") JUST_ARCH="x86_64" ;; \
+            "arm64") JUST_ARCH="aarch64" ;; \
+            *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+        esac && \
+        curl -sSL "https://github.com/casey/just/releases/download/1.36.0/just-1.36.0-${JUST_ARCH}-unknown-linux-musl.tar.gz" | tar -xz -C /usr/local/bin just && \
+        chmod +x /usr/local/bin/just
+RUN curl -L https://foundry.paradigm.xyz | bash && \
+    /root/.foundry/bin/foundryup && \
+    mv /root/.foundry/bin/* /usr/local/bin/ && \
+    rm -rf /root/.foundry
+  25 changes: 2 additions & 23 deletions25  
+Dockerfile-contracts
+

--- a/Dockerfile-contracts
+++ b/Dockerfile-contracts
@@ -1,18 +1,6 @@
 # Contracts build stage
-FROM golang:1.24 AS contracts-builder
+FROM okexchain/go-builder:v1 AS contracts-builder
 
-# Install dependencies for contract building
-RUN apt-get update && apt-get install -y \
-    curl \
-    git \
-    bash \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Install foundry
-RUN curl -L https://foundry.paradigm.xyz | bash && \
-    /root/.foundry/bin/foundryup && \
-    mv /root/.foundry/bin/* /usr/local/bin/ && \
-    rm -rf /root/.foundry
 
 WORKDIR /app
 
@@ -41,9 +29,7 @@ RUN --mount=type=cache,target=/root/.cache \
 # Create final contracts image with artifacts, foundry tools, and op-deployer
 FROM debian:bookworm-slim
 WORKDIR /app
-
-# Update certificates
-RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+# RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
 
 # Set environment variables for Go
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
@@ -51,13 +37,6 @@ ENV SSL_CERT_DIR=/etc/ssl/certs
 
 # Copy foundry tools for runtime use
 COPY --from=contracts-builder /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvil /usr/local/bin/
-
-# Verify foundry tools integrity
-RUN chmod +x /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvil && \
-    /usr/local/bin/forge --version > /dev/null && \
-    /usr/local/bin/cast --version > /dev/null && \
-    /usr/local/bin/anvil --version > /dev/null
-
 # Copy op-deployer binary
 COPY --from=contracts-builder /app/op-deployer/bin/ ./op-deployer/bin/
 

--- a/Dockerfile-opstack
+++ b/Dockerfile-opstack
@@ -1,30 +1,9 @@
 # Single stage build with Go
-FROM golang:1.24.4
-WORKDIR /app
-
-# Install all dependencies
+FROM okexchain/go-builder:v1
 RUN apt-get update && apt-get install -y \
-    curl \
-    git \
-    jq \
     docker.io \
-    make \
-    gcc \
-    nodejs \
-    npm \
-    bash \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Install just
-ARG TARGETARCH
-RUN case ${TARGETARCH} in \
-        "amd64") JUST_ARCH="x86_64" ;; \
-        "arm64") JUST_ARCH="aarch64" ;; \
-        *) echo "Unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
-    esac && \
-    curl -sSL "https://github.com/casey/just/releases/download/1.36.0/just-1.36.0-${JUST_ARCH}-unknown-linux-musl.tar.gz" | tar -xz -C /usr/local/bin just && \
-    chmod +x /usr/local/bin/just
-
+WORKDIR /app
 # Cache go dependencies first
 COPY go.mod go.sum ./
 COPY op-geth/ ./op-geth/
@@ -41,15 +20,3 @@ RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     make build-go-no-submodules
-
-# Copy foundry tools and artifacts from contracts image
-#COPY --from=op-contracts:latest /usr/local/bin/forge /usr/local/bin/cast /usr/local/bin/anvil /usr/local/bin/
-
-# Verify installations
-RUN echo "🔍 Verifying installations:" && \
-    which go && go version && \
-    which docker && docker --version && \
-#    which forge && forge --version && \
-    which just && just --version || echo "⚠️ Some tools not found"
-
-WORKDIR /app


### PR DESCRIPTION
… common base image

- Introduced a new Dockerfile for building with Go, including necessary dependencies and tools.
- Updated Dockerfile-contracts and Dockerfile-opstack to use a shared base image (okexchain/go-builder:v1) for consistency and reduced redundancy.
- Removed unnecessary installation steps and verification commands to streamline the build process.