### PR TITLE
perf(Transactor): Add more error info

### DIFF
--- a/packages/contracts-bedrock/src/periphery/Transactor.sol
+++ b/packages/contracts-bedrock/src/periphery/Transactor.sol
@@ -27,7 +27,7 @@ contract Transactor is Owned {
         returns (bool success_, bytes memory data_)
     {
         (success_, data_) = _target.call{ value: _value }(_data);
-        require(success_, "Transactor: CALL failed");
+        require(success_, string(abi.encodePacked("Transactor: CALL failed: ", data_)));
     }
 
     /// @notice Sends a DELEGATECALL to a target address.
@@ -46,6 +46,6 @@ contract Transactor is Owned {
     {
         // slither-disable-next-line controlled-delegatecall
         (success_, data_) = _target.delegatecall(_data);
-        require(success_, "Transactor: DELEGATECALL failed");
+        require(success_, string(abi.encodePacked("Transactor: DELEGATECALL failed: ", data_)));
     }
 }


### PR DESCRIPTION
This pull request updates the error messages in the `Transactor` contract to include the returned data from failed low-level calls. This change provides more detailed error information when `call` or `delegatecall` operations fail, making debugging easier.

Improved error reporting:

* Updated the `require` statements in the `call` and `delegatecall` functions of the `Transactor` contract to append the returned error data to the revert message, providing more context on failures. [[1]](diffhunk://#diff-b7b4e8ca09aecb55df90ee38265462d88b514f921084fae999ed718db160eaf7L30-R30) [[2]](diffhunk://#diff-b7b4e8ca09aecb55df90ee38265462d88b514f921084fae999ed718db160eaf7L49-R49)